### PR TITLE
Fix some of the linting ToC errors

### DIFF
--- a/src/epub/text/poetry.xhtml
+++ b/src/epub/text/poetry.xhtml
@@ -17096,7 +17096,7 @@
 			</p>
 		</article>
 		<article id="on-hearing-the-bag-pipe-and-seeing-the-stranger-played-at-inverary" epub:type="z3998:poem">
-			<h2 epub:type="title">On Hearing the Bag-Pipe and Seeing <i epub:type="se:name.publication.song">The Stranger</i> Played at Inverary</h2>
+			<h2 epub:type="title">On Hearing the Bag-Pipe and Seeing “The Stranger” Played at Inverary</h2>
 			<p>
 				<span>Of late two dainties were before me plac’d</span>
 				<br/>
@@ -21333,7 +21333,7 @@
 			</p>
 		</article>
 		<article id="a-dream-after-reading-dantes-episode-of-paolo-and-francesca" epub:type="z3998:poem">
-			<h2 epub:type="title">A Dream, After Reading Dante’s Episode of <i epub:type="se:name.publication.poem">Paolo and Francesca</i></h2>
+			<h2 epub:type="title">A Dream, After Reading Dante’s Episode of “Paolo and Francesca”</h2>
 			<p>
 				<span>As Hermes once rook to his feathers light,</span>
 				<br/>

--- a/src/epub/text/poetry.xhtml
+++ b/src/epub/text/poetry.xhtml
@@ -14051,7 +14051,7 @@
 		</article>
 		<article id="written-in-answer-to-a-sonnet-ending-thus" epub:type="z3998:poem">
 			<header>
-				<h2 epub:type="title">Written in Answer to a Sonnet Ending Thus:⁠—</h2>
+				<h2 epub:type="title">Written in Answer to a Sonnet Ending Thus</h2>
 				<blockquote epub:type="epigraph z3998:verse">
 					<p>
 						<span class="i1">“Dark eyes are dearer far</span>
@@ -16174,7 +16174,7 @@
 		</article>
 		<article id="acrostic-georgiana-augusta-keats" epub:type="z3998:poem">
 			<h2 epub:type="title">
-				<span>Acrostic:</span>
+				<span>Acrostic</span>
 				<span epub:type="subtitle">Georgiana Augusta Keats</span>
 			</h2>
 			<p>
@@ -17096,7 +17096,7 @@
 			</p>
 		</article>
 		<article id="on-hearing-the-bag-pipe-and-seeing-the-stranger-played-at-inverary" epub:type="z3998:poem">
-			<h2 epub:type="title">On Hearing the Bag-Pipe and Seeing “The Stranger” Played at Inverary</h2>
+			<h2 epub:type="title">On Hearing the Bag-Pipe and Seeing <i epub:type="se:name.publication.song">The Stranger</i> Played at Inverary</h2>
 			<p>
 				<span>Of late two dainties were before me plac’d</span>
 				<br/>
@@ -21333,7 +21333,7 @@
 			</p>
 		</article>
 		<article id="a-dream-after-reading-dantes-episode-of-paolo-and-francesca" epub:type="z3998:poem">
-			<h2 epub:type="title">A Dream, After Reading Dante’s Episode of “Paolo and Francesca”</h2>
+			<h2 epub:type="title">A Dream, After Reading Dante’s Episode of <i epub:type="se:name.publication.poem">Paolo and Francesca</i></h2>
 			<p>
 				<span>As Hermes once rook to his feathers light,</span>
 				<br/>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -556,7 +556,7 @@
 					<a href="text/poetry.xhtml#to-thomas-keats">To Thomas Keats</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#on-hearing-the-bag-pipe-and-seeing-the-stranger-played-at-inverary">On Hearing the Bag-Pipe and Seeing <i epub:type="se:name.publication.song">The Stranger</i> Played </a>
+					<a href="text/poetry.xhtml#on-hearing-the-bag-pipe-and-seeing-the-stranger-played-at-inverary">On Hearing the Bag-Pipe and Seeing “The Stranger” Played at Inverary</a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#mrs-cameron-and-ben-nevis"><abbr>Mrs.</abbr> Cameron and Ben Nevis</a>
@@ -797,7 +797,7 @@
 					<a href="text/poetry.xhtml#sonnet-9">Sonnet: “Why did I laugh to-night?”</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#a-dream-after-reading-dantes-episode-of-paolo-and-francesca">A Dream, After Reading Dante’s Episode of <i epub:type="se:name.publication.poem">Paolo and Francesca</i></a>
+					<a href="text/poetry.xhtml#a-dream-after-reading-dantes-episode-of-paolo-and-francesca">A Dream, After Reading Dante’s Episode of “Paolo and Francesca”</a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#ode-to-fanny">Ode to Fanny</a>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -65,7 +65,7 @@
 					<a href="text/poetry.xhtml#specimen-of-an-induction-to-a-poem">Specimen of an Induction to a Poem</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#calidore">Calidore: A Fragment</a>
+					<a href="text/poetry.xhtml#calidore">Calidore</a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#to-2">To ⸻</a>
@@ -145,7 +145,7 @@
 					<a href="text/poetry.xhtml#sonnet-7">Sonnet: “After dark vapours”</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#written-on-the-blank-space-at-the-end-of-chaucers-tale-of-the-floure-and-the-lefe">Written on the Blank Space at the End of Chaucer’s Tale of “The Floure and the Lefe”</a>
+					<a href="text/poetry.xhtml#written-on-the-blank-space-at-the-end-of-chaucers-tale-of-the-floure-and-the-lefe">Written on the Blank Space at the End of Chaucer’s Tale of <i epub:type="se:name.publication.poem">The Floure and the Lefe</i></a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#to-haydon">To Haydon</a>
@@ -154,7 +154,7 @@
 					<a href="text/poetry.xhtml#on-seeing-the-elgin-marbles">On Seeing the Elgin Marbles</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#on-leigh-hunts-poem-the-story-of-rimini">On Leigh Hunt’s Poem, “<i epub:type="se:name.publication.poem">The Story of Rimini</i>”</a>
+					<a href="text/poetry.xhtml#on-leigh-hunts-poem-the-story-of-rimini">On Leigh Hunt’s Poem, <i epub:type="se:name.publication.poem">The Story of Rimini</i></a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#to-leigh-hunt-esq">To Leigh Hunt, <abbr>Esq.</abbr></a>
@@ -273,7 +273,7 @@
 					</ol>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#on-sitting-down-to-read-king-lear-once-again">On Sitting Down to Read “<i epub:type="se:name.publication.play">King Lear</i>” Once Again</a>
+					<a href="text/poetry.xhtml#on-sitting-down-to-read-king-lear-once-again">On Sitting Down to Read <i epub:type="se:name.publication.play">King Lear</i> Once Again</a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#sonnet-8">Sonnet: “When I have fears”</a>
@@ -288,7 +288,7 @@
 					<a href="text/poetry.xhtml#to-the-nile">To the Nile</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#written-in-answer-to-a-sonnet-ending-thus">Written in Answer to a Sonnet Ending Thus:⁠—“Dark Eyes Are Dearer Far Than Those That Mock the Hyacinthine Bell.”</a>
+					<a href="text/poetry.xhtml#written-in-answer-to-a-sonnet-ending-thus">Written in Answer to a Sonnet Ending Thus</a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#to-homer">To Homer</a>
@@ -523,7 +523,7 @@
 					<a href="text/poetry.xhtml#two-or-three-posies">Two or Three Posies</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#acrostic-georgiana-augusta-keats">Acrostic: Georgiana Augusta Keats</a>
+					<a href="text/poetry.xhtml#acrostic-georgiana-augusta-keats">Acrostic</a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#a-song-about-myself">A Song About Myself</a>
@@ -556,7 +556,7 @@
 					<a href="text/poetry.xhtml#to-thomas-keats">To Thomas Keats</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#on-hearing-the-bag-pipe-and-seeing-the-stranger-played-at-inverary">On Hearing the Bag-Pipe and Seeing “<i epub:type="se:name.publication.song">The Stranger</i>” Played </a>
+					<a href="text/poetry.xhtml#on-hearing-the-bag-pipe-and-seeing-the-stranger-played-at-inverary">On Hearing the Bag-Pipe and Seeing <i epub:type="se:name.publication.song">The Stranger</i> Played </a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#mrs-cameron-and-ben-nevis"><abbr>Mrs.</abbr> Cameron and Ben Nevis</a>
@@ -565,7 +565,7 @@
 					<a href="text/poetry.xhtml#translation-from-a-sonnet-of-ronsard">Translation from a Sonnet of Ronsard</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#a-prophecy-to-george-keats-in-america">A Prophecy: To George Keats in America</a>
+					<a href="text/poetry.xhtml#a-prophecy-to-george-keats-in-america">A Prophecy</a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#song-3">Song: “I had a dove”</a>
@@ -589,7 +589,7 @@
 					<a href="text/poetry.xhtml#spenserian-stanza">Spenserian Stanza</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#hyperion">Hyperion: A Fragment</a>
+					<a href="text/poetry.xhtml#hyperion">Hyperion</a>
 					<ol>
 						<li>
 							<a href="text/poetry.xhtml#hyperion-1">Book <span epub:type="z3998:roman">I</span></a>
@@ -797,7 +797,7 @@
 					<a href="text/poetry.xhtml#sonnet-9">Sonnet: “Why did I laugh to-night?”</a>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#a-dream-after-reading-dantes-episode-of-paolo-and-francesca">A Dream, After Reading Dante’s Episode of Paolo and Francesca</a>
+					<a href="text/poetry.xhtml#a-dream-after-reading-dantes-episode-of-paolo-and-francesca">A Dream, After Reading Dante’s Episode of <i epub:type="se:name.publication.poem">Paolo and Francesca</i></a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#ode-to-fanny">Ode to Fanny</a>
@@ -958,7 +958,7 @@
 					</ol>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#the-cap-and-bells">The Cap and Bells; Or, the Jealousies</a>
+					<a href="text/poetry.xhtml#the-cap-and-bells">The Cap and Bells</a>
 					<ol>
 						<li>
 							<a href="text/poetry.xhtml#the-cap-and-bells-1" epub:type="z3998:roman">I</a>
@@ -1227,7 +1227,7 @@
 					</ol>
 				</li>
 				<li>
-					<a href="text/poetry.xhtml#to-george-keats-written-in-sickness">To George Keats, Written in Sickness</a>
+					<a href="text/poetry.xhtml#to-george-keats-written-in-sickness">To George Keats</a>
 				</li>
 				<li>
 					<a href="text/poetry.xhtml#the-last-sonnet">The Last Sonnet</a>


### PR DESCRIPTION
Remaining: errors with Song and Sonnet titles that need discussion, and two titlecase warnings that probably don’t apply.